### PR TITLE
Fix incorrect door removal processing

### DIFF
--- a/files/doors/init.lua
+++ b/files/doors/init.lua
@@ -356,7 +356,7 @@ function doors.register(name, def)
 	}}
 
 	def.after_dig_node = function(pos)
-		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
+		--minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
 		minetest.check_for_falling({x = pos.x, y = pos.y + 1, z = pos.z})
 	end
 
@@ -375,7 +375,7 @@ function doors.register(name, def)
 	end
 
 	def.on_destruct = function(pos)
-		minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
+		--minetest.remove_node({x = pos.x, y = pos.y + 1, z = pos.z})
 	end
 
 	def.drawtype = "mesh"


### PR DESCRIPTION
My doors were deleting blocks which was put in place of higher pseudo-block of the door, so I tried to build my own version without the bug, and it seems that removing these 2 rows fixes the issue.